### PR TITLE
Add public issues ranking demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# hello-world
+# Public Issues Ranking Demo
+
+This is a simple static website that demonstrates how public issues can be ranked and associated with organizations working on them. The data is stored in `data.json` and rendered dynamically using JavaScript.
+
+## Running Locally
+
+Open `index.html` in a modern web browser. Upvotes are stored using `localStorage`.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,89 @@
+{
+  "issues": [
+    {
+      "name": "Climate Change",
+      "rank": 1,
+      "trend": [68, 70, 72, 74, 76],
+      "organizations": [
+        {"name": "UNFCCC", "website": "https://unfccc.int"},
+        {"name": "Greenpeace", "website": "https://www.greenpeace.org"},
+        {"name": "350.org", "website": "https://350.org"},
+        {"name": "Sierra Club", "website": "https://www.sierraclub.org"},
+        {"name": "WWF", "website": "https://www.worldwildlife.org"},
+        {"name": "Climate Reality Project", "website": "https://www.climaterealityproject.org"},
+        {"name": "IPCC", "website": "https://www.ipcc.ch"},
+        {"name": "Friends of the Earth", "website": "https://foe.org"},
+        {"name": "Rainforest Alliance", "website": "https://www.rainforest-alliance.org"},
+        {"name": "CDP", "website": "https://www.cdp.net"}
+      ]
+    },
+    {
+      "name": "Economic Inequality",
+      "rank": 2,
+      "trend": [55, 57, 58, 60, 61],
+      "organizations": [
+        {"name": "Oxfam", "website": "https://www.oxfam.org"},
+        {"name": "World Bank", "website": "https://www.worldbank.org"},
+        {"name": "International Monetary Fund", "website": "https://www.imf.org"},
+        {"name": "Equality Trust", "website": "https://www.equalitytrust.org.uk"},
+        {"name": "UNDP", "website": "https://www.undp.org"},
+        {"name": "Brookings Institution", "website": "https://www.brookings.edu"},
+        {"name": "ILO", "website": "https://www.ilo.org"},
+        {"name": "Economic Policy Institute", "website": "https://www.epi.org"},
+        {"name": "WEF", "website": "https://www.weforum.org"},
+        {"name": "ActionAid", "website": "https://www.actionaid.org"}
+      ]
+    },
+    {
+      "name": "Public Health",
+      "rank": 3,
+      "trend": [60, 62, 61, 63, 65],
+      "organizations": [
+        {"name": "World Health Organization", "website": "https://www.who.int"},
+        {"name": "Doctors Without Borders", "website": "https://www.doctorswithoutborders.org"},
+        {"name": "CDC", "website": "https://www.cdc.gov"},
+        {"name": "Johns Hopkins Bloomberg School of Public Health", "website": "https://publichealth.jhu.edu"},
+        {"name": "Bill & Melinda Gates Foundation", "website": "https://www.gatesfoundation.org"},
+        {"name": "UNICEF", "website": "https://www.unicef.org"},
+        {"name": "Red Cross", "website": "https://www.redcross.org"},
+        {"name": "Gavi", "website": "https://www.gavi.org"},
+        {"name": "PATH", "website": "https://www.path.org"},
+        {"name": "World Bank Health", "website": "https://www.worldbank.org/en/topic/health"}
+      ]
+    },
+    {
+      "name": "Education Access",
+      "rank": 4,
+      "trend": [50, 51, 52, 53, 55],
+      "organizations": [
+        {"name": "UNESCO", "website": "https://en.unesco.org"},
+        {"name": "Education International", "website": "https://www.ei-ie.org"},
+        {"name": "Teach For All", "website": "https://teachforall.org"},
+        {"name": "World Bank Education", "website": "https://www.worldbank.org/en/topic/education"},
+        {"name": "Global Partnership for Education", "website": "https://www.globalpartnership.org"},
+        {"name": "Room to Read", "website": "https://www.roomtoread.org"},
+        {"name": "Save the Children", "website": "https://www.savethechildren.org"},
+        {"name": "Khan Academy", "website": "https://www.khanacademy.org"},
+        {"name": "UNICEF Education", "website": "https://www.unicef.org/education"},
+        {"name": "OECD Education", "website": "https://www.oecd.org/education"}
+      ]
+    },
+    {
+      "name": "Food Security",
+      "rank": 5,
+      "trend": [45, 46, 47, 48, 49],
+      "organizations": [
+        {"name": "World Food Programme", "website": "https://www.wfp.org"},
+        {"name": "Food and Agriculture Organization", "website": "https://www.fao.org"},
+        {"name": "Feeding America", "website": "https://www.feedingamerica.org"},
+        {"name": "Action Against Hunger", "website": "https://www.actionagainsthunger.org"},
+        {"name": "Heifer International", "website": "https://www.heifer.org"},
+        {"name": "USAID", "website": "https://www.usaid.gov"},
+        {"name": "Care", "website": "https://www.care.org"},
+        {"name": "World Bank Agriculture", "website": "https://www.worldbank.org/en/topic/agriculture"},
+        {"name": "Oxfam Hunger", "website": "https://www.oxfam.org/en/what-we-do/issues/hunger"},
+        {"name": "Farming First", "website": "https://farmingfirst.org"}
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Public Issues Ranking</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Public Issues Ranking</h1>
+    <div id="issues-container"></div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,78 @@
+async function loadData() {
+    const response = await fetch('data.json');
+    const data = await response.json();
+    renderIssues(data.issues);
+}
+
+function renderIssues(issues) {
+    const container = document.getElementById('issues-container');
+    issues.sort((a, b) => a.rank - b.rank);
+    issues.forEach(issue => {
+        const issueDiv = document.createElement('div');
+        issueDiv.className = 'issue';
+        const title = document.createElement('h2');
+        title.textContent = `${issue.rank}. ${issue.name}`;
+        issueDiv.appendChild(title);
+
+        const canvas = document.createElement('canvas');
+        canvas.className = 'trend';
+        issueDiv.appendChild(canvas);
+        drawTrend(canvas, issue.trend);
+
+        const orgList = document.createElement('ul');
+        orgList.className = 'organizations';
+        issue.organizations.forEach(org => {
+            const li = document.createElement('li');
+            li.className = 'organization';
+            const link = document.createElement('a');
+            link.href = org.website;
+            link.textContent = org.name;
+            link.target = '_blank';
+            li.appendChild(link);
+            const upvote = document.createElement('button');
+            upvote.className = 'upvote';
+            upvote.textContent = `\u2b06 ${getVotes(org.name)}`;
+            upvote.addEventListener('click', () => {
+                incrementVote(org.name);
+                upvote.textContent = `\u2b06 ${getVotes(org.name)}`;
+            });
+            li.appendChild(upvote);
+            orgList.appendChild(li);
+        });
+        issueDiv.appendChild(orgList);
+        container.appendChild(issueDiv);
+    });
+}
+
+function drawTrend(canvas, data) {
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width;
+    const h = canvas.height;
+    const max = Math.max(...data);
+    const min = Math.min(...data);
+    const padding = 5;
+    ctx.strokeStyle = '#008cba';
+    ctx.beginPath();
+    data.forEach((value, idx) => {
+        const x = padding + (w - 2 * padding) * (idx / (data.length - 1));
+        const y = h - padding - (h - 2 * padding) * ((value - min) / (max - min || 1));
+        if (idx === 0) {
+            ctx.moveTo(x, y);
+        } else {
+            ctx.lineTo(x, y);
+        }
+    });
+    ctx.stroke();
+}
+
+function getVotes(name) {
+    return parseInt(localStorage.getItem(`votes_${name}`)) || 0;
+}
+
+function incrementVote(name) {
+    const key = `votes_${name}`;
+    const current = getVotes(name);
+    localStorage.setItem(key, current + 1);
+}
+
+loadData();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0 1em;
+    background: #fafafa;
+}
+
+h1 {
+    text-align: center;
+}
+
+.issue {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 1em;
+    margin-bottom: 1em;
+    background: #fff;
+}
+
+.issue h2 {
+    margin-top: 0;
+}
+
+.organizations {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.organization {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5em 0;
+    border-top: 1px solid #eee;
+}
+
+.organization:first-child {
+    border-top: none;
+}
+
+.upvote {
+    background: #008cba;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 0.2em 0.5em;
+    cursor: pointer;
+}
+
+.trend {
+    width: 100%;
+    height: 50px;
+}


### PR DESCRIPTION
## Summary
- add a simple static site that lists public issues and related organizations
- include upvote functionality stored in localStorage
- show trend lines for each issue
- document how to run locally

## Testing
- `python3 - <<'PY'
import json, sys
with open('data.json') as f:
 data=json.load(f)
print('issues', len(data["issues"]))
for issue in data['issues']:
 print(issue['name'], 'orgs', len(issue['organizations']))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684656d818a08333b4b736a9adbc2646